### PR TITLE
add rocksdump subcommand

### DIFF
--- a/cmd/balboa/cmds/rocksdump.go
+++ b/cmd/balboa/cmds/rocksdump.go
@@ -1,0 +1,45 @@
+// balboa
+// Copyright (c) 2018, DCSO GmbH
+
+package cmds
+
+import (
+	"github.com/DCSO/balboa/db"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var rocksdumpCmd = &cobra.Command{
+	Use:   "rocksdump [netmask]",
+	Short: "Dump information from RocksDB",
+	Long:  `This command allows directly dump bulk information from RocksDB.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		if len(args) == 0 {
+			log.Fatal("needs database path as argument")
+		}
+
+		var verbose bool
+		verbose, err = cmd.Flags().GetBool("verbose")
+		if err != nil {
+			log.Fatal(err)
+		}
+		if verbose {
+			log.SetLevel(log.DebugLevel)
+		}
+
+		rdb, err := db.MakeRocksDBReadonly(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		rdb.Dump()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rocksdumpCmd)
+
+	rocksdumpCmd.Flags().BoolP("verbose", "v", false, "verbose mode")
+}

--- a/db/obs_rocksdb.h
+++ b/db/obs_rocksdb.h
@@ -34,9 +34,12 @@ void               obs_set_delete(ObsSet*);
 typedef struct ObsDB ObsDB;
 
 ObsDB*        obsdb_open(const char *path, uint64_t membudget, Error*);
+ObsDB*        obsdb_open_readonly(const char *path, Error*);
 int           obsdb_put(ObsDB *db, Observation *obs, Error*);
 ObsSet*       obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname, 
-                         const char *qrrtype, const char *qsensorID);
+                           const char *qrrtype, const char *qsensorID);
+int           obsdb_dump(ObsDB *db, Error *e) ;
+
 unsigned long obsdb_num_keys(ObsDB*);
 void          obsdb_close(ObsDB*);
 


### PR DESCRIPTION
This PR introduces the `balboa rocksdump` command, which -- when given a database directory -- dumps all observations in the database in JSON format to stdout. Keys corresponding to "inverted" rrdata-sorted data are skipped.