### PR TITLE
use consistent parameter types

### DIFF
--- a/db/obs_rocksdb.h
+++ b/db/obs_rocksdb.h
@@ -33,7 +33,7 @@ void               obs_set_delete(ObsSet*);
 
 typedef struct ObsDB ObsDB;
 
-ObsDB*        obsdb_open(const char *path, uint64_t membudget, Error*);
+ObsDB*        obsdb_open(const char *path, size_t membudget, Error*);
 ObsDB*        obsdb_open_readonly(const char *path, Error*);
 int           obsdb_put(ObsDB *db, Observation *obs, Error*);
 ObsSet*       obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname, 


### PR DESCRIPTION
Use `size_t` consistently across header and implementation.