### PR TITLE
add tests for format parsers

### DIFF
--- a/db/db_mysql.go
+++ b/db/db_mysql.go
@@ -7,10 +7,11 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/DCSO/balboa/observation"
+
 	// imported for side effects
 	_ "github.com/go-sql-driver/mysql"
 	log "github.com/sirupsen/logrus"
-	"github.com/DCSO/balboa/observation"
 )
 
 // create table observations (

--- a/format/format_fever.go
+++ b/format/format_fever.go
@@ -36,7 +36,8 @@ func MakeFeverAggregateInputObservations(inputJSON []byte, sensorID string, out 
 	var i int64
 	err := json.Unmarshal(inputJSON, &in)
 	if err != nil {
-		return err
+		log.Warn(err)
+		return nil
 	}
 	for k, v := range in.DNS {
 		select {

--- a/format/format_fever_test.go
+++ b/format/format_fever_test.go
@@ -1,0 +1,114 @@
+// balboa
+// Copyright (c) 2018, DCSO GmbH
+
+package format
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DCSO/balboa/observation"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestFeverFormatFail(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeFeverAggregateInputObservations([]byte(`babanana`), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 1 {
+		t.Fail()
+	}
+}
+
+func TestFeverFormatEmpty(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeFeverAggregateInputObservations([]byte(""), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 1 {
+		t.Fail()
+	}
+}
+
+const exampleInFever = `{
+    "dns": {
+        "foo.bar": {
+			"rdata": [
+				{
+					"rdata": "1.2.3.4",
+					"count":2,
+					"rrtype": "A",
+					"type":"answer"
+				},
+				{
+					"rdata": "1.2.3.5",
+					"count":1,
+					"rrtype": "A",
+					"type":"answer"
+				}
+			]
+		}
+    },
+    "timestamp_start":"2018-10-26T21:02:20+00:00",
+    "timestamp_end":"2018-10-26T21:03:20+00:00"
+}`
+
+func TestFeverFormat(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeFeverAggregateInputObservations([]byte(exampleInFever), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	close(resChan)
+	close(stopChan)
+
+	if len(hook.Entries) != 1 {
+		t.Fail()
+	}
+}

--- a/format/format_gamelinux.go
+++ b/format/format_gamelinux.go
@@ -18,7 +18,6 @@ import (
 // input in the format as used by https://github.com/gamelinux/passivedns.
 func MakeFjellskaalInputObservations(inputJSON []byte, sensorID string, out chan observation.InputObservation, stop chan bool) error {
 	var i int
-	log.Info(string(inputJSON))
 	scanner := bufio.NewScanner(strings.NewReader(string(inputJSON)))
 	for scanner.Scan() {
 		select {
@@ -29,6 +28,7 @@ func MakeFjellskaalInputObservations(inputJSON []byte, sensorID string, out chan
 			if len(vals) == 9 {
 				times := strings.Split(vals[0], ".")
 				if len(times) != 2 {
+					log.Warn("timestamp does not have form X.X")
 					continue
 				}
 				epoch, err := strconv.Atoi(times[0])
@@ -61,6 +61,8 @@ func MakeFjellskaalInputObservations(inputJSON []byte, sensorID string, out chan
 				}
 				i++
 				out <- o
+			} else {
+				log.Warn("number of columns != 9")
 			}
 		}
 	}

--- a/format/format_gamelinux_test.go
+++ b/format/format_gamelinux_test.go
@@ -1,0 +1,119 @@
+// balboa
+// Copyright (c) 2018, DCSO GmbH
+
+package format
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DCSO/balboa/observation"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestFjellskaalFormatFail(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeFjellskaalInputObservations([]byte("1322849924||10.1.1.1||8.8.8.8||IN||upload.youtube.com.||A||74.125.43.117||46587||5"), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeFjellskaalInputObservations([]byte("1322849924||10.1.1.1||8.8.8.8||upload.youtube.com.||A||74.125.43.117||46587||5"), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeFjellskaalInputObservations([]byte("X.2332||10.1.1.1||8.8.8.8||IN||upload.youtube.com.||A||74.125.43.117||46587||5"), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeFjellskaalInputObservations([]byte("X.X||10.1.1.1||8.8.8.8||IN||upload.youtube.com.||A||74.125.43.117||46587||5"), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeFjellskaalInputObservations([]byte("23232.X||10.1.1.1||8.8.8.8||IN||upload.youtube.com.||A||74.125.43.117||46587||5"), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeFjellskaalInputObservations([]byte("1322849924.244555||10.1.1.1||8.8.8.8||IN||upload.youtube.com.||A||74.125.43.117||46587||bar"), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 6 {
+		t.Fail()
+	}
+}
+
+func TestFjellskaalFormatEmpty(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeFjellskaalInputObservations([]byte(""), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 0 {
+		t.Fail()
+	}
+}
+
+const exampleInFjellskaal = `1322849924.408856||10.1.1.1||8.8.8.8||IN||upload.youtube.com.||A||74.125.43.117||46587||5
+1322849924.408857||10.1.1.1||8.8.8.8||IN||upload.youtube.com.||A||74.125.43.116||420509||5
+1322849924.408858||10.1.1.1||8.8.8.8||IN||www.adobe.com.||CNAME||www.wip4.adobe.com.||43200||8
+1322849924.408859||10.1.1.1||8.8.8.8||IN||www.adobe.com.||A||193.104.215.61||43200||8
+1322849924.408860||10.1.1.1||8.8.8.8||IN||i1.ytimg.com.||CNAME||ytimg.l.google.com.||43200||3
+1322849924.408861||10.1.1.1||8.8.8.8||IN||clients1.google.com.||A||173.194.32.3||43200||2
+`
+
+func TestFjellskaalFormat(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeFjellskaalInputObservations([]byte(exampleInFjellskaal), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	close(resChan)
+	close(stopChan)
+
+	if len(hook.Entries) != 0 {
+		t.Fail()
+	}
+}

--- a/format/format_gopassivedns.go
+++ b/format/format_gopassivedns.go
@@ -41,13 +41,13 @@ func MakeGopassivednsInputObservations(inputJSON []byte, sensorID string, out ch
 	var in dnsLogEntry
 	err := json.Unmarshal(inputJSON, &in)
 	if err != nil {
-		log.Info(err)
-		return err
+		log.Warn(err)
+		return nil
 	}
 	tst, err := time.Parse("2006-01-02 15:04:05.999999 -0700 MST", in.Timestamp)
 	if err != nil {
 		log.Info(err)
-		return err
+		return nil
 	}
 	o := observation.InputObservation{
 		Count:          1,

--- a/format/format_gopassivedns_test.go
+++ b/format/format_gopassivedns_test.go
@@ -1,0 +1,94 @@
+// balboa
+// Copyright (c) 2018, DCSO GmbH
+
+package format
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DCSO/balboa/observation"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestGopassivednsFormatFail(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeGopassivednsInputObservations([]byte(`{"query_id":43264,"rcode":0,"q":"github.com","qtype":"A","a":"192.30.253.112","atype":"A","ttl":60,"dst":"9.9.9.9","src":"192.168.1.79","tstamp":"2018-10-26 19 +0000 UTC","elapsed":35879000,"sport":"40651","level":"","bytes":102,"protocol":"udp","truncated":false,"aa":false,"rd":true,"ra":false}`), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 1 {
+		t.Fail()
+	}
+}
+
+func TestGopassivednsFormatEmpty(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeGopassivednsInputObservations([]byte(""), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 1 {
+		t.Fail()
+	}
+}
+
+const exampleInGopassivedns = `{"query_id":43264,"rcode":0,"q":"github.com","qtype":"A","a":"192.30.253.112","atype":"A","ttl":60,"dst":"9.9.9.9","src":"192.168.1.79","tstamp":"2018-10-26 19:32:36.141184 +0000 UTC","elapsed":35879000,"sport":"40651","level":"","bytes":102,"protocol":"udp","truncated":false,"aa":false,"rd":true,"ra":false}
+`
+
+func TestGopassivednsFormat(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeGopassivednsInputObservations([]byte(exampleInGopassivedns), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	close(resChan)
+	close(stopChan)
+
+	if len(hook.Entries) != 0 {
+		t.Fail()
+	}
+}

--- a/format/format_packetbeat.go
+++ b/format/format_packetbeat.go
@@ -35,16 +35,16 @@ func MakePacketbeatInputObservations(inputJSON []byte, sensorID string, out chan
 	var i int
 	err := json.Unmarshal(inputJSON, &in)
 	if err != nil {
-		log.Info(err)
-		return err
+		log.Warn(err)
+		return nil
 	}
 	if in.Type != "dns" {
 		return nil
 	}
 	tst, err := time.Parse("2006-01-02T15:04:05.999Z07", in.Timestamp)
 	if err != nil {
-		log.Info(err)
-		return err
+		log.Warn(err)
+		return nil
 	}
 	for _, answer := range in.DNS.Answers {
 		select {
@@ -64,6 +64,6 @@ func MakePacketbeatInputObservations(inputJSON []byte, sensorID string, out chan
 			out <- o
 		}
 	}
-	log.Debugf("enqueued %d observations", i)
+	log.Infof("enqueued %d observations", i)
 	return nil
 }

--- a/format/format_packetbeat_test.go
+++ b/format/format_packetbeat_test.go
@@ -1,0 +1,144 @@
+// balboa
+// Copyright (c) 2018, DCSO GmbH
+
+package format
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DCSO/balboa/observation"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestPacketbeatFormatFail(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakePacketbeatInputObservations([]byte(`babanana`), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakePacketbeatInputObservations([]byte(exampleInPacketbeatInvalidTimestamp), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakePacketbeatInputObservations([]byte(exampleInPacketbeatInvalidType), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 2 {
+		t.Fail()
+	}
+}
+
+func TestPacketbeatFormatEmpty(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakePacketbeatInputObservations([]byte(""), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 1 {
+		t.Fail()
+	}
+}
+
+const exampleInPacketbeatInvalidTimestamp = `{
+    "type": "dns",
+    "dns": {
+        "answers": [{
+            "name": "foo.bar.",
+            "data": "1.2.3.4.",
+            "type": "A",
+            "class":"foo"
+        }]
+
+    },
+    "@timestamp": "2018-10-26T2"
+}`
+
+const exampleInPacketbeatInvalidType = `{
+    "type": "whatever",
+    "dns": {
+        "answers": [{
+            "name": "foo.bar.",
+            "data": "1.2.3.4.",
+            "type": "A",
+            "class":"foo"
+        }]
+
+    },
+    "@timestamp": "2018-10-26T21:03:20.222Z"
+}`
+
+const exampleInPacketbeat = `{
+    "type": "dns",
+    "dns": {
+        "answers": [{
+            "name": "foo.bar.",
+            "data": "1.2.3.4.",
+            "type": "A",
+            "class":"foo"
+        }]
+
+    },
+    "@timestamp": "2018-10-26T21:03:20.222Z"
+}`
+
+func TestPacketbeatFormat(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation, 100)
+
+	stopChan := make(chan bool)
+	err := MakePacketbeatInputObservations([]byte(exampleInPacketbeat), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	close(resChan)
+	close(stopChan)
+
+	for o := range resChan {
+		resultObs = append(resultObs, o)
+	}
+
+	if len(resultObs) != 1 {
+		t.Fail()
+	}
+
+	if len(hook.Entries) != 1 {
+		t.Fail()
+	}
+}

--- a/format/format_suricata.go
+++ b/format/format_suricata.go
@@ -40,8 +40,8 @@ func MakeSuricataInputObservations(inputJSON []byte, sensorID string, out chan o
 	var i int
 	err := json.Unmarshal(inputJSON, &in)
 	if err != nil {
-		log.Info(err)
-		return err
+		log.Warn(err)
+		return nil
 	}
 	if in.EventType != "dns" {
 		return nil
@@ -51,8 +51,8 @@ func MakeSuricataInputObservations(inputJSON []byte, sensorID string, out chan o
 	}
 	tst, err := time.Parse("2006-01-02T15:04:05.999999-0700", in.Timestamp)
 	if err != nil {
-		log.Info(err)
-		return err
+		log.Warn(err)
+		return nil
 	}
 	if in.DNS.Version == 2 {
 		// v2 format
@@ -103,6 +103,6 @@ func MakeSuricataInputObservations(inputJSON []byte, sensorID string, out chan o
 		i++
 		out <- o
 	}
-	log.Debugf("enqueued %d observations", i)
+	log.Infof("enqueued %d observations", i)
 	return nil
 }

--- a/format/format_suricata_test.go
+++ b/format/format_suricata_test.go
@@ -1,0 +1,274 @@
+// balboa
+// Copyright (c) 2018, DCSO GmbH
+
+package format
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DCSO/balboa/observation"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestSuricataFormatFail(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeSuricataInputObservations([]byte(`babanana`), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeSuricataInputObservations([]byte(exampleInSuricataInvalidTimestamp), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeSuricataInputObservations([]byte(exampleInSuricataInvalidType), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeSuricataInputObservations([]byte(exampleInSuricataInvalidType2), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 2 {
+		t.Fail()
+	}
+}
+
+func TestSuricataFormatEmpty(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation)
+	go func() {
+		for o := range resChan {
+			resultObs = append(resultObs, o)
+		}
+	}()
+
+	stopChan := make(chan bool)
+	err := MakeSuricataInputObservations([]byte(""), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(resChan)
+	close(stopChan)
+
+	if len(resultObs) != 0 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 1 {
+		t.Fail()
+	}
+}
+
+const exampleInSuricataInvalidTimestamp = `{
+    "timestamp": "2009-11-24T21:",
+    "event_type": "dns",
+    "src_ip": "192.168.2.7",
+    "src_port": 53,
+    "dest_ip": "x.x.250.50",
+    "dest_port": 23242,
+    "proto": "UDP",
+    "dns": {
+		"type": "answer",
+		"id":16000,
+		"flags":"8180",
+		"qr":true,
+		"rd":true,
+		"ra":true,
+		"rcode":"NOERROR",
+		"rrname": "twitter.com",
+		"rrtype":"A",
+		"ttl":8,
+		"rdata": "199.16.156.6"
+	}
+}`
+
+const exampleInSuricataInvalidType = `{
+    "timestamp": "2009-11-24T21:27:09.534255-0100",
+    "event_type": "foo",
+    "src_ip": "192.168.2.7",
+    "src_port": 53,
+    "dest_ip": "x.x.250.50",
+    "dest_port": 23242,
+    "proto": "UDP",
+    "dns": {
+		"type": "answer",
+		"id":16000,
+		"flags":"8180",
+		"qr":true,
+		"rd":true,
+		"ra":true,
+		"rcode":"NOERROR",
+		"rrname": "twitter.com",
+		"rrtype":"A",
+		"ttl":8,
+		"rdata": "199.16.156.6"
+	}
+}`
+
+const exampleInSuricataInvalidType2 = `{
+    "timestamp": "2009-11-24T21:27:09.534255-0100",
+    "event_type": "dns",
+    "src_ip": "192.168.2.7",
+    "src_port": 53,
+    "dest_ip": "x.x.250.50",
+    "dest_port": 23242,
+    "proto": "UDP",
+    "dns": {
+		"type": "foo",
+		"id":16000,
+		"flags":"8180",
+		"qr":true,
+		"rd":true,
+		"ra":true,
+		"rcode":"NOERROR",
+		"rrname": "twitter.com",
+		"rrtype":"A",
+		"ttl":8,
+		"rdata": "199.16.156.6"
+	}
+}`
+
+const exampleInSuricataV2 = `{
+    "timestamp": "2009-11-24T21:27:09.534255-0100",
+    "event_type": "dns",
+    "src_ip": "192.168.2.7",
+    "src_port": 53,
+    "dest_ip": "x.x.250.50",
+    "dest_port": 23242,
+    "proto": "UDP",
+    "dns": {
+        "version": 2,
+        "type": "answer",
+        "id": 45444,
+        "flags": "8180",
+        "qr": true,
+        "rd": true,
+        "ra": true,
+        "rcode": "NOERROR",
+        "answers": [
+        {
+            "rrname": "www.suricata-ids.org",
+            "rrtype": "CNAME",
+            "ttl": 3324,
+            "rdata": "suricata-ids.org"
+        },
+        {
+            "rrname": "suricata-ids.org",
+            "rrtype": "A",
+            "ttl": 10,
+            "rdata": "192.0.78.24"
+        },
+        {
+            "rrname": "suricata-ids.org",
+            "rrtype": "A",
+            "ttl": 10,
+            "rdata": "192.0.78.25"
+        }
+        ]
+    }
+}`
+
+const exampleInSuricataV2Grouped = `{
+    "timestamp": "2009-11-24T21:27:09.534255-0100",
+    "event_type": "dns",
+    "src_ip": "192.168.2.7",
+    "src_port": 53,
+    "dest_ip": "x.x.250.50",
+    "dest_port": 23242,
+    "proto": "UDP",
+    "dns": {
+		"version": 2,
+		"type": "answer",
+		"id": 18523,
+		"flags": "8180",
+		"qr": true,
+		"rd": true,
+		"ra": true,
+		"rcode": "NOERROR",
+		"grouped": {
+		  "A": [
+			"192.0.78.24",
+			"192.0.78.25"
+		  ],
+		  "CNAME": [
+			"suricata-ids.org"
+		  ]
+		}
+	}
+}`
+
+const exampleInSuricataV1 = `{
+    "timestamp": "2009-11-24T21:27:09.534255-0100",
+    "event_type": "dns",
+    "src_ip": "192.168.2.7",
+    "src_port": 53,
+    "dest_ip": "x.x.250.50",
+    "dest_port": 23242,
+    "proto": "UDP",
+    "dns": {
+		"type": "answer",
+		"id":16000,
+		"flags":"8180",
+		"qr":true,
+		"rd":true,
+		"ra":true,
+		"rcode":"NOERROR",
+		"rrname": "twitter.com",
+		"rrtype":"A",
+		"ttl":8,
+		"rdata": "199.16.156.6"
+	}
+}`
+
+func TestSuricataFormat(t *testing.T) {
+	hook := test.NewGlobal()
+
+	resultObs := make([]observation.InputObservation, 0)
+	resChan := make(chan observation.InputObservation, 100)
+
+	stopChan := make(chan bool)
+	err := MakeSuricataInputObservations([]byte(exampleInSuricataV1), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeSuricataInputObservations([]byte(exampleInSuricataV2), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = MakeSuricataInputObservations([]byte(exampleInSuricataV2Grouped), "foo", resChan, stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	close(resChan)
+	close(stopChan)
+
+	for o := range resChan {
+		resultObs = append(resultObs, o)
+	}
+
+	if len(resultObs) != 7 {
+		t.Fail()
+	}
+	if len(hook.Entries) != 3 {
+		t.Fail()
+	}
+}

--- a/query/query_graphql.go
+++ b/query/query_graphql.go
@@ -10,13 +10,14 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/DCSO/balboa/db"
+	"github.com/DCSO/balboa/observation"
+
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/relay"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
-	"github.com/DCSO/balboa/db"
-	"github.com/DCSO/balboa/observation"
 )
 
 const (


### PR DESCRIPTION
This PR adds a test suite for the individual format parsers after unifying logging and error handling.
The idea is to keep parsing as much as possible, logging any errors that occur though.

```
coverage: 96.5% of statements
```