### PR TITLE
remove tpl dependency (used by rocksdb backend)

### DIFF
--- a/db/db_rocksdb.go
+++ b/db/db_rocksdb.go
@@ -3,7 +3,7 @@
 
 package db
 
-// #cgo LDFLAGS: -lrocksdb -ltpl
+// #cgo LDFLAGS: -lrocksdb
 // #cgo CFLAGS: -O3 -Wno-implicit-function-declaration -Wall -Wextra -Wno-unused-parameter
 // #include "obs_rocksdb.h"
 // #include <stdlib.h>

--- a/db/obs_rocksdb.c
+++ b/db/obs_rocksdb.c
@@ -9,13 +9,28 @@
 #include <stdio.h>
 #include <string.h>
 #include "rocksdb/c.h"
-#include "tpl.h"
 
 extern void cgoLogInfo(const char*);
 extern void cgoLogDebug(const char*);
 extern void cgoObsDump(Observation*);
 
 #define OBS_SET_STEP_SIZE 1000
+
+static inline void _write_u32_le( unsigned char* p, uint32_t v ){
+    p[0]=v>>0;
+    p[1]=v>>8;
+    p[2]=v>>16;
+    p[3]=v>>24;
+}
+
+static inline uint32_t _read_u32_le( const unsigned char* p ){
+    return(
+        (((uint32_t)p[0])<<0)
+       |(((uint32_t)p[1])<<8)
+       |(((uint32_t)p[2])<<16)
+       |(((uint32_t)p[3])<<24)
+    );
+}
 
 struct Error {
     char *msg;
@@ -32,44 +47,53 @@ Error* error_new()
 
 const char* error_get(Error *e)
 {
-    if (!e)
+    if (!e) {
         return NULL;
+    }
     return e->msg;
 }
 
 static void error_set(Error *e, const char *msg)
 {
-    if (!e)
+    if (!e) {
         return;
-    if (!msg)
+    }
+    if (!msg) {
         return;
-    if (e->msg)
+    }
+    if (e->msg) {
         free(e->msg);
+    }
     e->msg = strdup(msg);
 }
 
 void error_unset(Error *e)
 {
-    if (!e)
+    if (!e) {
         return;
-    if (e->msg)
+    }
+    if (e->msg) {
         free(e->msg);
+    }
     e->msg = NULL;
 }
 
 bool error_is_set(Error *e)
 {
-    if (!e)
+    if (!e) {
         return NULL;
+    }
     return (e->msg != NULL);
 }
 
 void error_delete(Error *e)
 {
-    if (!e)
+    if (!e) {
         return;
-    if (e->msg)
+    }
+    if (e->msg) {
         free(e->msg);
+    }
     free(e);
 }
 
@@ -79,11 +103,12 @@ struct ObsSet {
     Observation **os;
 };
 
-static ObsSet* obs_set_create(unsigned long size) 
+static ObsSet* obs_set_create(unsigned long size)
 {
     ObsSet *os = calloc((size_t) 1, sizeof(ObsSet));
-    if (!os)
+    if (!os) {
         return NULL;
+    }
     os->size = size;
     os->used = 0;
     os->os = calloc((size_t) size, sizeof(Observation*));
@@ -94,17 +119,19 @@ static ObsSet* obs_set_create(unsigned long size)
     return os;
 }
 
-unsigned long obs_set_size(ObsSet *os) 
+unsigned long obs_set_size(ObsSet *os)
 {
-    if (!os)
+    if (!os) {
         return 0;
+    }
     return os->used;
 }
 
 static void obs_set_add(ObsSet *os, Observation *o)
 {
-    if (!os || !os->os)
+    if (!os || !os->os) {
         return;
+    }
     if (os->used == os->size) {
         os->size += OBS_SET_STEP_SIZE;
         os->os = realloc(os->os, (size_t) (os->size * sizeof(Observation*)));
@@ -112,19 +139,22 @@ static void obs_set_add(ObsSet *os, Observation *o)
     os->os[os->used++] = o;
 }
 
-const Observation* obs_set_get(ObsSet *os, unsigned long i) 
+const Observation* obs_set_get(ObsSet *os, unsigned long i)
 {
-    if (!os)
+    if (!os) {
         return NULL;
-    if (i >= os->used)
+    }
+    if (i >= os->used) {
         return NULL;
+    }
     return os->os[i];
 }
 
-void obs_set_delete(ObsSet *os) 
+void obs_set_delete(ObsSet *os)
 {
-    if (!os)
+    if (!os) {
         return;
+    }
     if (os->os != NULL) {
         unsigned long i = 0;
         for (i = 0; i < os->used; i++) {
@@ -159,54 +189,57 @@ struct ObsDB {
        __typeof__ (b) _b = (b); \
      _a < _b ? _a : _b; })
 
-static inline int obs2buf(Observation *o, char **buf, size_t *buflen) {
-    uint32_t a,b,c;
-    int ret = 0;
-    tpl_node *tn = tpl_map("uuu", &a, &b, &c);
-    a = o->count;
-    b = o->last_seen;
-    c = o->first_seen;
-    ret = tpl_pack(tn, 0);
-    if (ret == 0) {
-        ret = tpl_dump(tn, TPL_MEM, buf, buflen);
+static inline int obs2buf(Observation *o, char *buf, size_t buflen) {
+    size_t minlen = sizeof(uint32_t)*3;
+    if (buflen < minlen) {
+        cgoLogInfo("serialize observation: buffer too short");
+        return -1;
     }
-    tpl_free(tn);
-    return ret;
+
+    unsigned char* p = (unsigned char*)buf;
+    _write_u32_le(p+0,o->count);
+    _write_u32_le(p+4,o->last_seen);
+    _write_u32_le(p+8,o->first_seen);
+
+    return 0;
 }
 
 static inline int buf2obs(Observation *o, const char *buf, size_t buflen) {
-    uint32_t a,b,c;
-    int ret = 0;
-    tpl_node *tn = tpl_map("uuu", &a, &b, &c);
-    ret = tpl_load(tn, TPL_MEM, buf, buflen);
-    if (ret == 0) {
-        (void) tpl_unpack(tn, 0);
-        o->count = a;
-        o->last_seen = b;
-        o->first_seen = c;
-    }
-    tpl_free(tn);
-    return ret;
+    size_t minlen = sizeof(uint32_t)*3;
+    if (buflen < minlen) {
+        cgoLogInfo("deserialize observation: buffer too short");
+        return -1;
+    };
+
+    const unsigned char* p = (const unsigned char*)buf;
+    o->count = _read_u32_le(p+0);
+    o->last_seen = _read_u32_le(p+4);
+    o->first_seen = _read_u32_le(p+8);
+
+    return 0;
 }
 
 static char* obsdb_mergeop_full_merge(void *state, const char* key,
                                size_t key_length, const char* existing_value,
                                size_t existing_value_length,
                                const char* const* operands_list,
-                               const size_t* operands_list_length, 
+                               const size_t* operands_list_length,
                                int num_operands, unsigned char* success,
                                size_t* new_value_length)
 {
     Observation obs = {NULL, NULL, 0, 0, 0};
 
     if (key_length < 1) {
-        fprintf(stderr, "full merge: key too short\n");
+        cgoLogInfo("full merge: key too short");
         *success = (unsigned char) 0;
-        return NULL; 
+        return NULL;
     }
     if (key[0] == 'i') {
         /* this is an inverted index key with no meaningful value */
-        char *res = malloc(1 * sizeof(char));
+        char *res = malloc(sizeof(char)*1);
+        if (res==NULL) {
+            return NULL;
+        }
         *res = '\0';
         *new_value_length = 1;
         *success = 1;
@@ -214,8 +247,9 @@ static char* obsdb_mergeop_full_merge(void *state, const char* key,
     } else if (key[0] == 'o') {
         /* this is an observation value */
         int i;
-        size_t buflength;
-        char *buf = NULL;
+        size_t buflength = sizeof(uint32_t)*3;
+        char *buf = malloc(buflength);
+        if (buf==NULL) { return NULL; }
         if (existing_value) {
             buf2obs(&obs, existing_value, existing_value_length);
         }
@@ -223,7 +257,7 @@ static char* obsdb_mergeop_full_merge(void *state, const char* key,
             Observation nobs = {NULL, NULL, 0, 0, 0};
             buf2obs(&nobs, operands_list[i], operands_list_length[i]);
             if (i == 0) {
-                if (!existing_value) {
+                if (existing_value == NULL) {
                     obs.count = nobs.count;
                     obs.last_seen = nobs.last_seen;
                     obs.first_seen = nobs.first_seen;
@@ -238,15 +272,15 @@ static char* obsdb_mergeop_full_merge(void *state, const char* key,
                 obs.first_seen = obsdb_min(obs.first_seen, nobs.first_seen);
             }
         }
-        obs2buf(&obs, &buf, &buflength);
+        obs2buf(&obs, buf, buflength);
         *new_value_length = buflength;
         *success = (unsigned char) 1;
         return buf;
     } else {
         /* weird key format! */
-        fprintf(stderr, "full merge: weird key format\n");
+        cgoLogInfo("full merge: weird key format");
         *success = (unsigned char) 0;
-        return NULL; 
+        return NULL;
     }
 }
 
@@ -260,13 +294,14 @@ static char* obsdb_mergeop_partial_merge(void *state, const char* key,
     Observation obs = {NULL, NULL, 0, 0, 0};
 
     if (key_length < 1) {
-        fprintf(stderr, "partial merge: key too short\n");
+        cgoLogInfo("partial merge: key too short");
         *success = (unsigned char) 0;
-        return NULL; 
+        return NULL;
     }
     if (key[0] == 'i') {
         /* this is an inverted index key with no meaningful value */
-        char *res = malloc(1 * sizeof(char));
+        char *res = malloc(sizeof(char)*1);
+        if (res == NULL) { return NULL; }
         *res = '\0';
         *new_value_length = 1;
         *success = 1;
@@ -274,8 +309,9 @@ static char* obsdb_mergeop_partial_merge(void *state, const char* key,
     } else if (key[0] == 'o') {
         /* this is an observation value */
         int i;
-        size_t buflength;
-        char *buf = NULL;
+        size_t buflength=sizeof(uint32_t)*3;
+        char *buf = malloc(buflength);
+        if (buf==NULL) { return NULL; }
         for (i = 0; i < num_operands; i++) {
             Observation nobs = {NULL, NULL, 0, 0, 0};
             buf2obs(&nobs, operands_list[i], operands_list_length[i]);
@@ -289,15 +325,15 @@ static char* obsdb_mergeop_partial_merge(void *state, const char* key,
                 obs.first_seen = obsdb_min(obs.first_seen, nobs.first_seen);
             }
         }
-        obs2buf(&obs, &buf, &buflength);
+        obs2buf(&obs, buf, buflength);
         *new_value_length = buflength;
         *success = (unsigned char) 1;
         return buf;
     } else {
         /* weird key format! */
-        fprintf(stderr, "partial merge: weird key format\n");
+        cgoLogInfo("partial merge: weird key format");
         *success = (unsigned char) 0;
-        return NULL; 
+        return NULL;
     }
 }
 
@@ -305,7 +341,7 @@ static void obsdb_mergeop_destructor(void *state)
 {
     return;
 }
- 
+
 static const char* obsdb_mergeop_name(void *state)
 {
     return "observation mergeop";
@@ -323,8 +359,9 @@ static ObsDB* _obsdb_open(const char *path, size_t membudget, Error *e, bool rea
     };
     ObsDB *db = calloc(1, sizeof(ObsDB));
     if (db == NULL) {
-        if (e)
+        if (e) {
             error_set(e, "could not allocate memory");
+        }
         return NULL;
     }
 
@@ -337,8 +374,9 @@ static ObsDB* _obsdb_open(const char *path, size_t membudget, Error *e, bool rea
 
     db->options = rocksdb_options_create();
     rocksdb_options_increase_parallelism(db->options, 8);
-    if (!readonly)
+    if (!readonly) {
         rocksdb_options_optimize_level_style_compaction(db->options, membudget);
+    }
     rocksdb_options_set_create_if_missing(db->options, 1);
     rocksdb_options_set_max_log_file_size(db->options, 10*1024*1024);
     rocksdb_options_set_keep_log_file_num(db->options, 2);
@@ -346,13 +384,15 @@ static ObsDB* _obsdb_open(const char *path, size_t membudget, Error *e, bool rea
     rocksdb_options_set_merge_operator(db->options, db->mergeop);
     rocksdb_options_set_compression_per_level(db->options, level_compression, 5);
 
-    if (!readonly)
+    if (!readonly) {
         db->db = rocksdb_open(db->options, path, &err);
-    else
+    } else {
         db->db = rocksdb_open_for_read_only(db->options, path, 0, &err);
+    }
     if (err) {
-        if (e)
+        if (e) {
             error_set(e, err);
+        }
         free(err);
         return NULL;
     }
@@ -371,33 +411,35 @@ ObsDB* obsdb_open_readonly(const char *path, Error *e) {
     return _obsdb_open(path, 0, e, true);
 }
 
-int obsdb_put(ObsDB *db, Observation *obs, Error *e) 
+int obsdb_put(ObsDB *db, Observation *obs, Error *e)
 {
-    char *err = NULL;  
-    size_t buflength;
-    char *buf;
-    if (!db)
+    char *err = NULL;
+    char buf[sizeof(uint32_t)*3];
+    size_t buflength = sizeof(buf);
+
+    if (!db) {
         return -1;
+    }
 
-    (void) obs2buf(obs, &buf, &buflength);
+    (void) obs2buf(obs, buf, buflength);
 
-    rocksdb_merge(db->db, db->writeoptions, obs->key, strlen(obs->key), 
+    rocksdb_merge(db->db, db->writeoptions, obs->key, strlen(obs->key),
                 buf, buflength, &err);
     if (err) {
-        if (e)
+        if (e) {
             error_set(e, err);
+        }
         free(err);
-        free(buf);
         return -1;
 
     }
-    free(buf);
 
     rocksdb_merge(db->db, db->writeoptions, obs->inv_key, strlen(obs->key),
                 "", 0, &err);
     if (err) {
-        if (e)
+        if (e) {
             error_set(e, err);
+        }
         free(err);
         return -1;
     }
@@ -408,8 +450,9 @@ int obsdb_put(ObsDB *db, Observation *obs, Error *e)
 int obsdb_dump(ObsDB *db, Error *e)
 {
     rocksdb_iterator_t *it;
-    if (!db)
+    if (!db) {
         return -1;
+    }
 
     it = rocksdb_create_iterator(db->db, db->readoptions);
     for (rocksdb_iter_seek(it, "o", 1);
@@ -435,7 +478,7 @@ int obsdb_dump(ObsDB *db, Error *e)
         val = rocksdb_iter_value(it, &size);
         ret = buf2obs(o, val, size);
         if (ret != 0) {
-            fprintf(stderr, "error\n");
+            cgoLogInfo("error");
         }
         cgoObsDump(o);
         free(o->key);
@@ -446,13 +489,14 @@ int obsdb_dump(ObsDB *db, Error *e)
     return 0;
 }
 
-ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname, 
-                         const char *qrrtype, const char *qsensorID) 
+ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname,
+                         const char *qrrtype, const char *qsensorID)
 {
     rocksdb_iterator_t *it;
     ObsSet *os;
-    if (!db)
+    if (!db) {
         return NULL;
+    }
 
     os = obs_set_create(OBS_SET_STEP_SIZE);
 
@@ -466,15 +510,15 @@ ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname,
                 obs_set_delete(os);
                 return NULL;
             }
-            (void) snprintf(prefix, prefixlen, "o%c%s%c%s%c", 0x1f, qrrname, 0x1f, qsensorID, 0x1f);
+            (void) snprintf(prefix, prefixlen-1, "o\x1f%s\x1f%s\x1f", qrrname, qsensorID);
         } else {
             prefixlen = strlen(qrrname) + 3;
-            prefix = calloc(prefixlen, sizeof(char));
+            prefix = calloc(prefixlen-1, sizeof(char));
             if (!prefix) {
                 obs_set_delete(os);
                 return NULL;
             }
-            (void) snprintf(prefix, prefixlen, "o%c%s%c", 0x1f, qrrname, 0x1f);
+            (void) snprintf(prefix, prefixlen-1, "o\x1f%s\x1f", qrrname);
         }
         cgoLogDebug(prefix);
 
@@ -493,7 +537,7 @@ ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname,
                 free(prefix);
                 return NULL;
             }
-                        
+
             strncpy(tokkey, rkey, size);
             tokkey[size] = '\0';
             rrname = strtok_r(tokkey+2, "\x1f", &saveptr);
@@ -560,7 +604,7 @@ ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname,
                 obs_set_delete(os);
                 return NULL;
             }
-            (void) snprintf(prefix, prefixlen, "i%c%s%c%s%c", 0x1f, qrdata, 0x1f, qsensorID, 0x1f);
+            (void) snprintf(prefix, prefixlen-1, "i\x1f%s\x1f%s\x1f", qrdata, qsensorID);
         } else {
             prefixlen = strlen(qrdata) + 3;
             prefix = calloc(prefixlen, sizeof(char));
@@ -568,7 +612,7 @@ ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname,
                 obs_set_delete(os);
                 return NULL;
             }
-            (void) snprintf(prefix, prefixlen, "i%c%s%c", 0x1f, qrdata, 0x1f);
+            (void) snprintf(prefix, prefixlen-1, "i\x1f%s\x1f", qrdata);
         }
         cgoLogDebug(prefix);
 
@@ -590,7 +634,7 @@ ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname,
                 free(prefix);
                 return NULL;
             }
-            
+
             strncpy(tokkey, rkey, size);
             tokkey[size] = '\0';
             rdata = strtok_r(tokkey+2, "\x1f", &saveptr);
@@ -618,8 +662,10 @@ ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname,
                 tokkey = NULL;
                 continue;
             }
-            
-            (void) snprintf(fullkey, 4096, "o%c%s%c%s%c%s%c%s", 0x1f, rrname, 0x1f, sensorID, 0x1f, rrtype, 0x1f, rdata);
+
+            bzero(fullkey,4096);
+            (void) snprintf(fullkey, 4095, "o\x1f%s\x1f%s\x1f%s\x1f%s", rrname, sensorID, rrtype, rdata);
+
             cgoLogDebug(fullkey);
 
             fullkeylen = strlen(fullkey);
@@ -641,7 +687,7 @@ ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname,
                 return NULL;
             }
             o->key = calloc(fullkeylen + 1, sizeof(char));
-            if (!o->key) {
+            if (o->key==NULL) {
                 free(o);
                 free(tokkey);
                 obs_set_delete(os);
@@ -667,11 +713,12 @@ ObsSet* obsdb_search(ObsDB *db, const char *qrdata, const char *qrrname,
     return os;
 }
 
-unsigned long obsdb_num_keys(ObsDB *db) 
+unsigned long obsdb_num_keys(ObsDB *db)
 {
     const char *val;
-    if (!db)
+    if (!db) {
         return 0;
+    }
     val = rocksdb_property_value(db->db, "rocksdb.estimate-num-keys");
     if (!val) {
         return 0;
@@ -689,8 +736,9 @@ unsigned long obsdb_num_keys(ObsDB *db)
 
 void obsdb_close(ObsDB *db)
 {
-    if (!db)
+    if (!db) {
         return;
+    }
     rocksdb_mergeoperator_destroy(db->mergeop);
     rocksdb_writeoptions_destroy(db->writeoptions);
     rocksdb_readoptions_destroy(db->readoptions);


### PR DESCRIPTION
Stored observations as rocksdb values are not backwards compatible.
The database needs to be rebuilt.