### PR TITLE
add systemd service files

### DIFF
--- a/balboa-backend@.service
+++ b/balboa-backend@.service
@@ -6,7 +6,7 @@ Before=balboa.service
 
 [Service]
 SyslogIdentifier=balboa-%i
-EnvironmentFile=-/etc/default/balboa-backend
+EnvironmentFile=-/etc/default/balboa-%i
 ExecStart=/usr/bin/balboa-%i $BALBOA_BACKEND_ARGS
 ExecStop=/usr/bin/pkill balboa-%i
 PIDFile=/var/run/balboa/balboa-%i.pid

--- a/balboa-backend@.service
+++ b/balboa-backend@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Basic Little Book of Answers, '%i' Backend
+Documentation=https://github.com/DCSO/balboa
+After=network.target
+Before=balboa.service
+
+[Service]
+SyslogIdentifier=balboa-%i
+EnvironmentFile=-/etc/default/balboa-backend
+ExecStart=/usr/bin/balboa-%i $BALBOA_BACKEND_ARGS
+ExecStop=/usr/bin/pkill balboa-%i
+PIDFile=/var/run/balboa/balboa-%i.pid
+LimitNOFILE=200000
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target balboa.service

--- a/balboa.service
+++ b/balboa.service
@@ -9,7 +9,6 @@ EnvironmentFile=-/etc/default/balboa
 ExecStart=/usr/bin/balboa serve $BALBOA_ARGS
 ExecStop=/usr/bin/pkill balboa
 PIDFile=/var/run/balboa/balboa.pid
-LimitNOFILE=200000
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
This PR introduces a new service template for the backends. It starts a backend depending on its template parameter, e.g.

```
$ systemctl start balboa-backend@rocksdb
```

would start the RocksDB backend, `balboa-rocksdb`. Additional parameters can be given in the `$BALBOA_BACKEND_ARGS` environment variable defined, for instance, in `/etc/default/balboa-backend`.