### PR TITLE
WIP: add support for multiple sensor queries

### DIFF
--- a/feeders.yaml
+++ b/feeders.yaml
@@ -1,9 +1,4 @@
 feeder:
-    - name: AMQPInput2
-      type: amqp
-      url: amqp://guest:guest@localhost:5672
-      exchange: [ tdh.pdns ]
-      input_format: fever_aggregate 
     - name: HTTP Input
       type: http
       listen_host: 127.0.0.1

--- a/query/query_graphql.go
+++ b/query/query_graphql.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/DCSO/balboa/db"
@@ -175,7 +176,7 @@ const (
 		# Providing rdata, rrname, rrtype and/or sensor_id will restrict the
 		# results to the set of observations that match all of the given
 		# constraints.
-		entries(rdata: String, rrname: String, rrtype: RRType, sensor_id: String, limit: Int = 1000): [Entry]
+		entries(rdata: String, rrname: String, rrtype: RRType, sensor_id: [String], limit: Int = 1000): [Entry]
 
 		# Returns some runtime values describing the current state of the database.
 		stats(): Stats
@@ -207,7 +208,7 @@ func (r *Resolver) Entries(args struct {
 	Rdata    *string
 	Rrname   *string
 	Rrtype   *string
-	SensorID *string
+	SensorID *[]*string
 	Limit    int32
 }) (*[]*EntryResolver, error) {
 	startTime := time.Now()
@@ -229,7 +230,11 @@ func (r *Resolver) Entries(args struct {
 			rrtype = ("nil")
 		}
 		if args.SensorID != nil {
-			sensorID = *args.SensorID
+			sensorIDs := make([]string, 0)
+			for _, sid := range *args.SensorID {
+				sensorIDs = append(sensorIDs, *sid)
+			}
+			sensorID = strings.Join(sensorIDs, ",")
 		} else {
 			sensorID = ("nil")
 		}
@@ -242,15 +247,30 @@ func (r *Resolver) Entries(args struct {
 			Message: "at least one of the 'rdata' or 'rrname' parameters is required",
 		}
 	}
-	results, err := db.ObservationDB.Search(args.Rdata, args.Rrname, args.Rrtype, args.SensorID, int(args.Limit))
-	if err != nil {
-		return nil, err
-	}
-	for _, r := range results {
-		er := EntryResolver{
-			entry: r,
+	if args.SensorID == nil {
+		results, err := db.ObservationDB.Search(args.Rdata, args.Rrname, args.Rrtype, nil, int(args.Limit))
+		if err != nil {
+			return nil, err
 		}
-		l = append(l, &er)
+		for _, r := range results {
+			er := EntryResolver{
+				entry: r,
+			}
+			l = append(l, &er)
+		}
+	} else {
+		for _, sid := range *args.SensorID {
+			results, err := db.ObservationDB.Search(args.Rdata, args.Rrname, args.Rrtype, sid, int(args.Limit))
+			if err != nil {
+				return nil, err
+			}
+			for _, r := range results {
+				er := EntryResolver{
+					entry: r,
+				}
+				l = append(l, &er)
+			}
+		}
 	}
 	return &l, nil
 }


### PR DESCRIPTION
This PR addresses #35, allowing a query for more than one sensor ID in the `entries()` query. This is backwards compatible, since
```graphql
query {
  entries(rdata:"1.2.3.4", sensor_id:["foo"]) {
    rrname
    sensor_id
  }
}
```
seems to be equivalent to 
```graphql
query {
  entries(rdata:"1.2.3.4", sensor_id:"foo") {
    rrname
    sensor_id
  }
}
```
which matches the previously used syntax.