### PR TITLE
Adjust README for building from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The balboa software...
 - can accept input from multiple sources simultaneously
   - HTTP (POST)
   - AMQP
-  - GraphQL
   - Unix socket
 - accepts various (text-based) input formats
   - JSON-based

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ The balboa software...
 ## Building and Installation
 
 ```text
-$ go get github.com/DCSO/balboa
+$ go get github.com/DCSO/balboa/cmd/balboa
 ...
 ```
+This will drop a `balboa` executable in your Go bin path.
 
 To build the backends:
 


### PR DESCRIPTION
The current documentation still lists old syntax from before using Cobra for the CLI.
This PR adjusts the README to reflect the current state and also updates minor details.