### PR TITLE
Add CIRCL-like REST query service

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ passive DNS data aggregated from metadata gathered by
 The API should be suitable for integration into existing multi-source
 observable integration frameworks. It is possible to produce results in a
 [Common Output Format](https://datatracker.ietf.org/doc/draft-dulaunoy-dnsop-passive-dns-cof/)
-compatible schema using the GraphQL API. In fact, the GraphQL schema is
-modelled after the COF fields.
+compatible schema using either a GraphQL API (see below) or a REST API compatible with
+[CIRCL's](https://www.circl.lu/services/passive-dns/).
 
 The balboa software...
 
 - is fast for queries and input/updates
-- implements persistent, compressed storage of observations
+- implements storage using pluggable backends, potentially on separate machines
 - supports tracking and specifically querying multiple sensors
-- makes use of multi-core systems
-- can accept input from multiple sources simultaneously
+- makes use of multiple cores for query and ingest
+- accepts input from multiple sources simultaneously
   - HTTP (POST)
   - AMQP
   - Unix socket
@@ -63,7 +63,7 @@ This will create a binary executable in the `build/` subdirectories of each back
 ### Dependencies
 
 - Go 1.10 or later
-- [RocksDB](https://rocksdb.org/) 5.0 or later (shared lib, with LZ4 support)
+- For the bundled RocksDB backend: [RocksDB](https://rocksdb.org/) 5.0 or later (shared lib, with LZ4 support)
 
 On Debian (testing and stretch-backports), one can satisfy these dependencies with:
 

--- a/cmd/balboa/cmds/serve.go
+++ b/cmd/balboa/cmds/serve.go
@@ -1,10 +1,9 @@
 // balboa
-// Copyright (c) 2018, DCSO GmbH
+// Copyright (c) 2018, 2020, DCSO GmbH
 
 package cmds
 
 import (
-	"github.com/DCSO/balboa/selector"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -15,6 +14,8 @@ import (
 	"github.com/DCSO/balboa/feeder"
 	"github.com/DCSO/balboa/observation"
 	"github.com/DCSO/balboa/query"
+	"github.com/DCSO/balboa/selector"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/balboa/cmds/serve.go
+++ b/cmd/balboa/cmds/serve.go
@@ -152,7 +152,7 @@ answering queries.`,
 			selectorEngine.ConsumeFeed(observation.InChan)
 		}
 
-		// start query server
+		// start GraphQL query server
 		var port int
 		port, err = cmd.Flags().GetInt("port")
 		if err != nil {
@@ -160,6 +160,18 @@ answering queries.`,
 		}
 		gql := query.GraphQLFrontend{}
 		gql.Run(int(port))
+
+		// start REST query server
+		var rport int
+		rport, err = cmd.Flags().GetInt("rest-port")
+		if err != nil {
+			log.Fatal(err)
+		}
+		if rport != 0 {
+			rq := query.RESTFrontend{}
+			rq.Run(int(rport))
+		}
+
 		sigChan := make(chan os.Signal, 1)
 		done := make(chan bool, 1)
 		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
@@ -185,6 +197,7 @@ func init() {
 	serveCmd.Flags().StringP("feeders", "f", "feeders.yaml", "feeders configuration file")
 	serveCmd.Flags().StringP("selectors", "s", "selectors.yaml", "selectors configuration file")
 	serveCmd.Flags().IntP("port", "p", 8080, "port for GraphQL server")
+	serveCmd.Flags().IntP("rest-port", "r", 8088, "port for REST server")
 	serveCmd.Flags().StringP("logfile", "l", "/var/log/balboa.log", "log file path")
 	serveCmd.Flags().BoolP("logjson", "j", true, "output log file as JSON")
 	serveCmd.Flags().StringP("backend", "b", "backend.yaml", "backend configuration file")

--- a/db/db_dummy.go
+++ b/db/db_dummy.go
@@ -1,0 +1,66 @@
+// balboa
+// Copyright (c) 2020, DCSO GmbH
+
+package db
+
+import (
+	"github.com/DCSO/balboa/observation"
+)
+
+type MockDB struct {
+	obs []observation.Observation
+}
+
+func MakeMockDB() *MockDB {
+	return &MockDB{
+		obs: make([]observation.Observation, 0),
+	}
+}
+
+func (m *MockDB) ConsumeFeed(inChan chan observation.InputObservation) {
+	for in := range inChan {
+		o := observation.Observation{
+			RRName:    in.Rrname,
+			RRType:    in.Rrtype,
+			Count:     in.Count,
+			RData:     in.Rdata,
+			FirstSeen: in.TimestampStart,
+			LastSeen:  in.TimestampEnd,
+			SensorID:  in.SensorID,
+		}
+		m.obs = append(m.obs, o)
+	}
+}
+
+func (m *MockDB) Backup(path string) {
+	return
+}
+
+func (m *MockDB) Dump(path string) {
+	return
+}
+
+func (m *MockDB) Shutdown() {
+	return
+}
+
+func (m *MockDB) TotalCount() (int, error) {
+	return len(m.obs), nil
+}
+
+func (m *MockDB) Search(qrdata, qrrname, qrrtype, qsensorID *string, limit int) ([]observation.Observation, error) {
+	retObs := make([]observation.Observation, 0)
+	for _, o := range m.obs {
+		if qrdata != nil {
+			if *qrdata == o.RData {
+				retObs = append(retObs, o)
+			}
+		}
+		if qrrname != nil {
+			if *qrrname == o.RRName {
+				retObs = append(retObs, o)
+			}
+		}
+	}
+	return retObs, nil
+}

--- a/observation/observation.go
+++ b/observation/observation.go
@@ -35,3 +35,20 @@ func (o *Observation) MarshalJSON() ([]byte, error) {
 		Alias:     (*Alias)(o),
 	})
 }
+
+func (o *Observation) UnmarshalJSON(data []byte) error {
+	type Alias Observation
+	tmp := &struct {
+		FirstSeen int64 `json:"time_first"`
+		LastSeen  int64 `json:"time_last"`
+		*Alias
+	}{
+		Alias: (*Alias)(o),
+	}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	o.FirstSeen = time.Unix(tmp.FirstSeen, 0)
+	o.LastSeen = time.Unix(tmp.LastSeen, 0)
+	return nil
+}

--- a/observation/observation.go
+++ b/observation/observation.go
@@ -4,8 +4,10 @@
 package observation
 
 import (
-	uuid "github.com/satori/go.uuid"
+	"encoding/json"
 	"time"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 // Observation represents a DNS answer, potentially repeated, observed on a
@@ -19,4 +21,17 @@ type Observation struct {
 	RRName    string    `json:"rrname" codec:"N"`
 	RData     string    `json:"rdata" codec:"D"`
 	SensorID  string    `json:"sensor_id" codec:"I"`
+}
+
+func (o *Observation) MarshalJSON() ([]byte, error) {
+	type Alias Observation
+	return json.Marshal(&struct {
+		FirstSeen int64 `json:"time_first"`
+		LastSeen  int64 `json:"time_last"`
+		*Alias
+	}{
+		FirstSeen: o.FirstSeen.UTC().Unix(),
+		LastSeen:  o.LastSeen.UTC().Unix(),
+		Alias:     (*Alias)(o),
+	})
 }

--- a/query/query_graphql_test.go
+++ b/query/query_graphql_test.go
@@ -1,0 +1,198 @@
+// balboa
+// Copyright (c) 2020, DCSO GmbH
+
+package query
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/DCSO/balboa/db"
+	"github.com/DCSO/balboa/observation"
+)
+
+func makeGraphQLQuery(t *testing.T, keyword, addr, field string) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString(`{"query":"query { entries(` + field + `:\"` + keyword + `\") { rrname rdata time_first time_last count rrtype sensor_id }}"}`)
+	targetURL := "http://" + addr + "/query"
+	resp, err := http.Post(targetURL, "application/json", &buf)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+type graphQLObservationResult struct {
+	Data struct {
+		Entries []struct {
+			Rrname    string
+			Rdata     string
+			Count     uint
+			Rrtype    string
+			TimeFirst uint
+			TimeLast  uint
+			SensorID  string `json:"sensor_id"`
+		}
+	}
+}
+
+func parseGraphQLResult(t *testing.T, body []byte) []observation.Observation {
+	var qlres graphQLObservationResult
+	err := json.Unmarshal(body, &qlres)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := make([]observation.Observation, 0)
+	for _, e := range qlres.Data.Entries {
+		o := observation.Observation{
+			RRName:    e.Rrname,
+			RData:     e.Rdata,
+			RRType:    e.Rrtype,
+			Count:     e.Count,
+			FirstSeen: time.Unix(int64(e.TimeFirst), 0),
+			LastSeen:  time.Unix(int64(e.TimeLast), 0),
+			SensorID:  e.SensorID,
+		}
+		res = append(res, o)
+	}
+	return res
+}
+
+var gq GraphQLFrontend
+
+func testGraphQLQueryOne(t *testing.T) {
+	// run queries: foo
+	body, err := makeGraphQLQuery(t, "foo", gq.GetAddr(), "rrname")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := parseGraphQLResult(t, body)
+	if len(res) != 1 {
+		t.Fatalf("unexpected length of result: %d", len(res))
+	}
+	if res[0].RRName != "foo" {
+		t.Fatalf("unexpected result rrname: %s", res[0].RRName)
+	}
+}
+
+func testGraphQLQueryAnother(t *testing.T) {
+	// run queries: foo
+	body, err := makeGraphQLQuery(t, "bar", gq.GetAddr(), "rrname")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := parseGraphQLResult(t, body)
+	if len(res) != 1 {
+		t.Fatalf("unexpected length of result: %d", len(res))
+	}
+	if res[0].RRName != "bar" {
+		t.Fatalf("unexpected result rrname: %s", res[0].RRName)
+	}
+}
+
+func testGraphQLQueryTwo(t *testing.T) {
+	// run queries: bar
+	body, err := makeGraphQLQuery(t, "1.2.3.4", gq.GetAddr(), "rdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := parseGraphQLResult(t, body)
+	if len(res) != 2 {
+		t.Fatalf("unexpected length of result: %d", len(res))
+	}
+	if res[0].RRName != "foo" {
+		t.Fatalf("unexpected result rrname: %s", res[0].RRName)
+	}
+	if res[1].RRName != "baz" {
+		t.Fatalf("unexpected result rrname: %s", res[1].RRName)
+	}
+}
+
+func testGraphQLQueryEmpty(t *testing.T) {
+	// run queries: valid query path but nonexisting keyword
+	body, err := makeGraphQLQuery(t, "nonexist", gq.GetAddr(), "rrname")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := parseGraphQLResult(t, body)
+	if len(res) != 0 {
+		t.Fatalf("unexpected length of result: %d", len(res))
+	}
+}
+
+func testGraphQLQueryFail(t *testing.T) {
+	// run queries: failed query due to invalid path
+	resp, err := http.Get("http://" + gq.GetAddr() + fmt.Sprintf("/blurb/foo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unexpected status %d", resp.StatusCode)
+	}
+}
+
+func TestQueryGraphQL(t *testing.T) {
+	// import test data
+	db.ObservationDB = db.MakeMockDB()
+	inChan := make(chan observation.InputObservation, 100)
+	go db.ObservationDB.ConsumeFeed((inChan))
+	inChan <- observation.InputObservation{
+		Rrname:         "foo",
+		Rdata:          "1.2.3.4",
+		Rrtype:         "A",
+		Count:          10,
+		SensorID:       "abc",
+		TimestampStart: time.Now(),
+		TimestampEnd:   time.Now().Add(1 * time.Second),
+	}
+	inChan <- observation.InputObservation{
+		Rrname:         "bar",
+		Rdata:          "1.2.3.5",
+		Rrtype:         "A",
+		Count:          10,
+		SensorID:       "abc",
+		TimestampStart: time.Now(),
+		TimestampEnd:   time.Now().Add(1 * time.Second),
+	}
+	inChan <- observation.InputObservation{
+		Rrname:         "baz",
+		Rdata:          "1.2.3.4",
+		Rrtype:         "A",
+		Count:          1,
+		SensorID:       "abc",
+		TimestampStart: time.Now(),
+		TimestampEnd:   time.Now().Add(1 * time.Second),
+	}
+	for v, _ := db.ObservationDB.TotalCount(); v < 3; v, _ = db.ObservationDB.TotalCount() {
+		time.Sleep(10 * time.Millisecond)
+	}
+	close(inChan)
+
+	// create test frontend on random free port
+	gq = GraphQLFrontend{}
+	listener, err := net.Listen("tcp", fmt.Sprintf(":0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gq.RunWithListener(listener)
+	t.Run("QueryOne", testGraphQLQueryOne)
+	t.Run("QueryAnother", testGraphQLQueryAnother)
+	t.Run("QueryTwo", testGraphQLQueryTwo)
+	t.Run("QueryEmpty", testGraphQLQueryEmpty)
+	t.Run("QueryFail", testGraphQLQueryFail)
+	gq.Stop()
+}

--- a/query/query_rest.go
+++ b/query/query_rest.go
@@ -1,0 +1,107 @@
+// balboa
+// Copyright (c) 2020, DCSO GmbH
+
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/DCSO/balboa/db"
+	"github.com/DCSO/balboa/observation"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// defaultLimit specifies the default limit to use if not given as a GET
+	// parameter.
+	defaultLimit = 1000
+	// queryPathPrefix specifies the HTTP GET path prefix before the actual
+	// search subject string.
+	queryPathPrefix = "/pdns/query/"
+)
+
+// RESTFrontend represents a concurrent component that provides a HTTP-based
+// query interface for the database. It is meant to be compatible with CIRCL's
+// interface as described in https://www.circl.lu/services/passive-dns/.
+type RESTFrontend struct {
+	Server    *http.Server
+	IsRunning bool
+}
+
+type restHandler struct{}
+
+func (rh *restHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !strings.HasPrefix(r.URL.Path, queryPathPrefix) {
+		w.WriteHeader(404)
+		return
+	}
+	subject := strings.Replace(r.URL.Path, queryPathPrefix, "", -1)
+	allres := make([]observation.Observation, 0)
+
+	var limit int64 = defaultLimit
+	limParams, ok := r.URL.Query()["limit"]
+	if ok && len(limParams[0]) == 1 {
+		limVal, err := strconv.ParseInt(limParams[0], 10, 32)
+		if err == nil {
+			limit = limVal
+		}
+	}
+
+	results, err := db.ObservationDB.Search(nil, &subject, nil, nil, int(limit))
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	allres = append(allres, results...)
+	results, err = db.ObservationDB.Search(&subject, nil, nil, nil, int(limit))
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	allres = append(allres, results...)
+
+	if len(allres) == 0 {
+		w.WriteHeader(404)
+		return
+	}
+	for _, rs := range allres {
+		json, err := json.Marshal(&rs)
+		if err == nil {
+			w.Write(json)
+			w.Write([]byte("\n"))
+		}
+	}
+}
+
+// Run starts this instance of a RESTFrontend in the background, accepting
+// new requests on the configured port.
+func (g *RESTFrontend) Run(port int) {
+	handler := &restHandler{}
+	g.Server = &http.Server{
+		Addr:         fmt.Sprintf(":%v", port),
+		Handler:      handler,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+	log.Infof("serving CIRCL-like REST on port %v", port)
+	go func() {
+		err := g.Server.ListenAndServe()
+		if err != nil {
+			log.Info(err)
+		}
+		g.IsRunning = true
+	}()
+}
+
+// Stop causes this instance of a RESTFrontend to cease accepting requests.
+func (g *RESTFrontend) Stop() {
+	if g.IsRunning {
+		g.Server.Shutdown(context.TODO())
+	}
+}

--- a/query/query_rest_test.go
+++ b/query/query_rest_test.go
@@ -1,0 +1,174 @@
+// balboa
+// Copyright (c) 2020, DCSO GmbH
+
+package query
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DCSO/balboa/db"
+	"github.com/DCSO/balboa/observation"
+)
+
+func makeRESTQuery(t *testing.T, keyword, addr string) ([]byte, error) {
+	resp, err := http.Get("http://" + addr + fmt.Sprintf("/pdns/query/%s", keyword))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func parseRESTResult(t *testing.T, body []byte) []observation.Observation {
+	res := make([]observation.Observation, 0)
+	for _, line := range strings.Split(string(body), "\n") {
+		if len(line) == 0 {
+			continue
+		}
+		var o observation.Observation
+		err := json.Unmarshal([]byte(line), &o)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res = append(res, o)
+	}
+	return res
+}
+
+var rq RESTFrontend
+
+func testRESTQueryOne(t *testing.T) {
+	// run queries: foo
+	body, err := makeRESTQuery(t, "foo", rq.GetAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := parseRESTResult(t, body)
+	if len(res) != 1 {
+		t.Fatalf("unexpected length of result: %d", len(res))
+	}
+	if res[0].RRName != "foo" {
+		t.Fatalf("unexpected result rrname: %s", res[0].RRName)
+	}
+}
+
+func testRESTQueryAnother(t *testing.T) {
+	// run queries: foo
+	body, err := makeRESTQuery(t, "bar", rq.GetAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := parseRESTResult(t, body)
+	if len(res) != 1 {
+		t.Fatalf("unexpected length of result: %d", len(res))
+	}
+	if res[0].RRName != "bar" {
+		t.Fatalf("unexpected result rrname: %s", res[0].RRName)
+	}
+}
+
+func testRESTQueryTwo(t *testing.T) {
+	// run queries: bar
+	body, err := makeRESTQuery(t, "1.2.3.4", rq.GetAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := parseRESTResult(t, body)
+	if len(res) != 2 {
+		t.Fatalf("unexpected length of result: %d", len(res))
+	}
+	if res[0].RRName != "foo" {
+		t.Fatalf("unexpected result rrname: %s", res[0].RRName)
+	}
+	if res[1].RRName != "baz" {
+		t.Fatalf("unexpected result rrname: %s", res[1].RRName)
+	}
+}
+
+func testRESTQueryEmpty(t *testing.T) {
+	// run queries: valid query path but nonexisting keyword
+	_, err := makeRESTQuery(t, "nonexist", rq.GetAddr())
+	if err == nil {
+		t.Fatal("missing error")
+	}
+	if err.Error() != "status 404" {
+		t.Fatalf("wrong error message: %s", err.Error())
+	}
+}
+
+func testRESTQueryFail(t *testing.T) {
+	// run queries: failed query due to invalid path
+	resp, err := http.Get("http://" + rq.GetAddr() + fmt.Sprintf("/blurb/foo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unexpected status %d", resp.StatusCode)
+	}
+}
+
+func TestQueryREST(t *testing.T) {
+	// import test data
+	db.ObservationDB = db.MakeMockDB()
+	inChan := make(chan observation.InputObservation, 100)
+	go db.ObservationDB.ConsumeFeed((inChan))
+	inChan <- observation.InputObservation{
+		Rrname:         "foo",
+		Rdata:          "1.2.3.4",
+		Rrtype:         "A",
+		Count:          10,
+		SensorID:       "abc",
+		TimestampStart: time.Now(),
+		TimestampEnd:   time.Now().Add(1 * time.Second),
+	}
+	inChan <- observation.InputObservation{
+		Rrname:         "bar",
+		Rdata:          "1.2.3.5",
+		Rrtype:         "A",
+		Count:          10,
+		SensorID:       "abc",
+		TimestampStart: time.Now(),
+		TimestampEnd:   time.Now().Add(1 * time.Second),
+	}
+	inChan <- observation.InputObservation{
+		Rrname:         "baz",
+		Rdata:          "1.2.3.4",
+		Rrtype:         "A",
+		Count:          1,
+		SensorID:       "abc",
+		TimestampStart: time.Now(),
+		TimestampEnd:   time.Now().Add(1 * time.Second),
+	}
+	for v, _ := db.ObservationDB.TotalCount(); v < 3; v, _ = db.ObservationDB.TotalCount() {
+		time.Sleep(10 * time.Millisecond)
+	}
+	close(inChan)
+
+	// create test frontend on random free port
+	rq = RESTFrontend{}
+	listener, err := net.Listen("tcp", fmt.Sprintf(":0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rq.RunWithListener(listener)
+	t.Run("QueryOne", testRESTQueryOne)
+	t.Run("QueryAnother", testRESTQueryAnother)
+	t.Run("QueryTwo", testRESTQueryTwo)
+	t.Run("QueryEmpty", testRESTQueryEmpty)
+	t.Run("QueryFail", testRESTQueryFail)
+	rq.Stop()
+}


### PR DESCRIPTION
I have found some local commits and some stuff in my `git stash` which could make a useful feature.
This PR introduces the following changes:

- Addition of a new optional HTTP REST query server, started alongside the GraphQL one and based on the same database backend connection. It follows the well-known query/response format as described by CIRCL in https://www.circl.lu/services/passive-dns/ and is compatible with clients that usually talk to that service. This makes it easier to casually query the database without having to write GraphQL queries. Both can be used completely in parallel.
- Adjustment of `Observation` marshal/unmarshal behaviour to transparently convert between `time.Time` and Unix timestamps.
- Addition of a simple toy DB implementation for unit testing.
- Extension of the `RESTFrontend` and `GraphQLFrontend` APIs to accept a custom `net.Listener` on creation. This makes it possible to bind to random ports at instantiation time, making unit tests possible.
- Addition of previously missing tests for REST and GraphQL server.