### PR TITLE
update CI environment and deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,17 +5,14 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.10-stretch
+      - image: circleci/golang:1.14-buster
 
     working_directory: /go/src/github.com/DCSO/balboa
     steps:
       - checkout
       - run:
-          name: Add stretch-backports
-          command: 'echo "deb http://ftp.debian.org/debian stretch-backports main" | sudo tee -a /etc/apt/sources.list.d/backports.list'
-      - run:
           name: Install apt dependencies
-          command: 'sudo apt-get update && sudo apt-get -t stretch-backports install librocksdb-dev -y'
+          command: 'sudo apt-get update && sudo apt-get install librocksdb-dev -y'
 
       # specify any bash command here prefixed with `run: `
       - run: go get -v -t -d ./...

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271
 	github.com/tiago4orion/conjure v0.0.0-20150908101743-93cb30b9d218 // indirect
-	github.com/ugorji/go/codec v1.1.7
+	github.com/ugorji/go/codec v1.1.12
 	github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb
 	gopkg.in/yaml.v2 v2.2.4
 )


### PR DESCRIPTION
Some of the old module definitions specify dependency versions that do not compile on older Go versions any more. This leads to consistent CI failures and blocks #60  and #59.
This commit bumps the `ugorji/go/codec dependency` version as well as the Debian and Go versions used in CI.