### PR TITLE
Address reconnects and protocol stability in backend communication 

### DIFF
--- a/db/db_remote.go
+++ b/db/db_remote.go
@@ -1,15 +1,15 @@
 // balboa
-// Copyright (c) 2019, DCSO GmbH
+// Copyright (c) 2019, 2025, DCSO GmbH
 
 package db
 
 import (
-	"gopkg.in/yaml.v2"
 	"net"
 
 	obs "github.com/DCSO/balboa/observation"
 
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 type Backend struct {
@@ -109,8 +109,22 @@ func (db *RemoteBackend) ConsumeFeed(inChan chan obs.InputObservation) {
 					wanted := w.Len()
 					n, err := w.WriteTo(*conn)
 					if err != nil {
-						log.Warnf("sending observation failed: %s", err)
-						continue
+						log.Warnf("sending observation failed: %s, reconnecting", err)
+						(*conn).Close()
+						// try to reconnect
+						newConn, err := net.Dial("tcp", (*conn).RemoteAddr().String())
+						if err != nil {
+							log.Warnf("reconnecting to backend failed: %s", err)
+							continue
+						}
+						*conn = newConn
+						// and try again
+						n, err = w.WriteTo(*conn)
+						if err != nil {
+							log.Warnf("retry sending observation failed: %s", err)
+							(*conn).Close()
+							continue
+						}
 					}
 					if n != int64(wanted) {
 						log.Warnf("short write")

--- a/observation/input_observation.go
+++ b/observation/input_observation.go
@@ -18,8 +18,8 @@ type InputObservation struct {
 	SensorID       string                   `codec:"I"`
 	TimestampEnd   time.Time                `codec:"L"`
 	TimestampStart time.Time                `codec:"F"`
-	Tags           map[string]struct{}      `codec:"G,omitempty"`
-	Selectors      map[interface{}]struct{} `codec:"S,omitempty"`
+	Tags           map[string]struct{}      `codec:"-,omitempty"`
+	Selectors      map[interface{}]struct{} `codec:"-,omitempty"`
 }
 
 // InChan is the global input channel delivering InputObservations from


### PR DESCRIPTION
This PR introduces the following changes:

* Enable reconnects when the TCP connection to a backend host goes away. Even if the backend service immediately restarts, the client code had no way of reestablishing a new connection.
* Make sure that fields (e.g. tags, selectors) recently added to the `InputObservation` struct do not end up in the msgpack messages. The backend is not prepared to see them in the input.