### PR TITLE
Various fixes and improvements

### DIFF
--- a/backend/balboa-backend-console/main.c
+++ b/backend/balboa-backend-console/main.c
@@ -1,5 +1,5 @@
 // balboa
-// Copyright (c) 2019, 2020, DCSO GmbH
+// Copyright (c) 2019, 2026, DCSO GmbH
 
 #include <arpa/inet.h>
 #include <assert.h>
@@ -177,6 +177,7 @@ static int main_query(int argc, char** argv) {
     case 'v': trace_config.verbosity += 1; break;
     case 'h': engine_config.host = opt.arg; break;
     case 'p': engine_config.port = atoi(opt.arg); break;
+    case 'l': query->limit = atoi(opt.arg); break;
     case 'd':
       if(opt.arg == NULL) {
         L(log_emergency("string for option `-d` required"));
@@ -364,6 +365,17 @@ Command dump:\n\
     -p <port> port of the `balboa-backend` (default: 4242)\n\
     -v increase verbosity; can be passed multiple times\n\
     -d <remote-dump-path> unused/ignored (default: -)\n\
+\n\
+Command query:\n\
+    execute a query against the database\n\
+\n\
+    -h <host> ip address of the `balboa-backend` (default: 127.0.0.1)\n\
+    -p <port> port of the `balboa-backend` (default: 4242)\n\
+    -r <rrname> rrname to query for\n\
+    -d <rdata> rdata to query for\n\
+    -s <sensorid> sensorid to filter by\n\
+    -l <limit> maximum number of results (default: 100)\n\
+    -v increase verbosity; can be passed multiple times\n\
 \n\
 Command replay:\n\
     replay a previously generated database dump\n\

--- a/backend/balboa-rocksdb/rocksdb-impl.c
+++ b/backend/balboa-rocksdb/rocksdb-impl.c
@@ -1,5 +1,5 @@
 // balboa
-// Copyright (c) 2018, 2019 DCSO GmbH
+// Copyright (c) 2018, 2026 DCSO GmbH
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -467,6 +467,10 @@ static int blb_rocksdb_query_by_i(
     keys_visited += 1;
     size_t key_len = 0;
     const char* key = rocksdb_iter_key(it, &key_len);
+    if(key_len < prefix_len
+       || memcmp(key, dbc->scrtch_inv, prefix_len) != 0) {
+      break;
+    }
     char* err = NULL;
 
     enum TokIdx { RDATA = 3, SENSORID = 2, RRNAME = 1, RRTYPE = 0, FIELDS = 4 };

--- a/backend/lib/alloc.h
+++ b/backend/lib/alloc.h
@@ -1,5 +1,5 @@
 // balboa
-// Copyright (c) 2018, 2019 DCSO GmbH
+// Copyright (c) 2018, 2026 DCSO GmbH
 
 #ifndef __ALLOC_H
 #define __ALLOC_H
@@ -10,8 +10,10 @@
 
 static inline void* blb_realloc_impl(
     const char* name, void* p, size_t new_size) {
+  uintptr_t old_addr = (uintptr_t)p;
   void* pp = realloc(p, new_size);
-  X(log_debug("(%s) realloc `%p` `%p` `%zu`", name, p, pp, new_size));
+  X(log_debug(
+      "(%s) realloc `0x%" PRIxPTR "` `%p` `%zu`", name, old_addr, pp, new_size));
   return (pp);
 }
 
@@ -32,8 +34,9 @@ static inline void* blb_realloc_impl(
 #define blb_realloc(p, sz)                                \
   ({                                                      \
     size_t p_sz = (sz);                                   \
+    uintptr_t old_addr = (uintptr_t)(p);                  \
     void* pp = realloc((p), p_sz);                        \
-    X(log_debug("realloc `%p` `%zu` `%p`", pp, p_sz, p)); \
+    X(log_debug("realloc `0x%" PRIxPTR "` `%zu` `%p`", old_addr, p_sz, pp)); \
     pp;                                                   \
   })
 #define blb_free(p)                 \


### PR DESCRIPTION
This MR introduces the following changes:

* Add early prefix check in `blb_rocksdb_query_by_i()` to break out of the iterator loop immediately when keys no longer match the seek prefix. This avoids unnecessary iteration and parsing of keys that are lexicographically close but cannot match
* Fix GCC `-Wuse-after-free` warning by capturing the old pointer address as `uintptr_t` before calling `realloc()`, then logging the integer value instead of the potentially-freed pointer.
* `balboa-backend-console`: add `-l` option to set query result limit as well as add documentation for the `query` command in usage text
