### PR TITLE
chore: remove obsolete Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: go
-arch : 
-  - amd64
-  - ppc64le
-sudo: false
-script:
-  - go vet ./...
-  - go test -v ./...


### PR DESCRIPTION
We no longer use Travis CI and switched to GitHub Actions in 2022. Let's get rid of this old config file in the project root.